### PR TITLE
Disable paho client reconnect on failure

### DIFF
--- a/asyncio_mqtt/client.py
+++ b/asyncio_mqtt/client.py
@@ -122,6 +122,7 @@ class Client:
             protocol=protocol,
             clean_session=clean_session,
             transport=transport,
+            reconnect_on_failure=False,
         )
         self._client.on_connect = self._on_connect
         self._client.on_disconnect = self._on_disconnect
@@ -470,7 +471,7 @@ class Client:
     ) -> None:
         def cb() -> None:
             # client.loop_read() may raise an exception, such as BadPipe. It's
-            # usually a sign that the underlaying connection broke, therefore we 
+            # usually a sign that the underlaying connection broke, therefore we
             # disconnect straight away
             try:
                 client.loop_read()
@@ -502,7 +503,7 @@ class Client:
     ) -> None:
         def cb() -> None:
             # client.loop_write() may raise an exception, such as BadPipe. It's
-            # usually a sign that the underlaying connection broke, therefore we 
+            # usually a sign that the underlaying connection broke, therefore we
             # disconnect straight away
             try:
                 client.loop_write()

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     ],
     keywords="mqtt async asyncio paho-mqtt wrapper",
     install_requires=[
-        "paho-mqtt>=1.5.0",
+        "paho-mqtt>=1.6.0",
         "async_generator;python_version<'3.7'",
     ],
 )


### PR DESCRIPTION
- Set option to not reconnect in the paho mqtt client automatically. The reconnection used to be done in the event loop, ie blocking the event loop.
- Require paho-mqtt version >=1.6.0, which is the version the `reconnect_on_failure` option was added.

- Example test while connecting to mosquitto broker which has `allow_zero_length_clientid` set to false, using protocol 3.1.1 and empty client id. The client will now not try to re-connect automatically and the connect times out, letting us try again explicitly if we want.
```
2021-10-26 16:14:53,248 INFO (MainThread) [asyncio_mqtt] Starting client example.
2021-10-26 16:14:53,248 DEBUG (MainThread) [asyncio] Using selector: EpollSelector
2021-10-26 16:14:53,263 DEBUG (ThreadPoolExecutor-0_0) [asyncio_mqtt] Sending CONNECT (u0, p0, wr0, wq0, wf0, c1, k60) client_id=b''
Error "Operation timed out". Reconnecting in 3 seconds.
2021-10-26 16:15:06,288 DEBUG (ThreadPoolExecutor-0_0) [asyncio_mqtt] Sending CONNECT (u0, p0, wr0, wq0, wf0, c1, k60) client_id=b''
Error "Operation timed out". Reconnecting in 3 seconds.
^C2021-10-26 16:15:17,240 INFO (MainThread) [asyncio_mqtt] Exiting client example.
```

fixes #26