### PR TITLE
feat: match topic before message enters queue

### DIFF
--- a/aiomqtt/client.py
+++ b/aiomqtt/client.py
@@ -571,6 +571,7 @@ class Client:
         *,
         queue_class: type[asyncio.Queue[Message]] = asyncio.Queue,
         queue_maxsize: int = 0,
+        topic: str = None,
     ) -> AsyncGenerator[AsyncGenerator[Message, None], None]:
         """Return async generator of incoming messages.
 
@@ -579,7 +580,7 @@ class Client:
         If queue_maxsize is less than or equal to zero, the queue size is infinite.
         """
         callback, generator = self._callback_and_generator(
-            queue_class=queue_class, queue_maxsize=queue_maxsize
+            queue_class=queue_class, queue_maxsize=queue_maxsize, topic=topic
         )
         try:
             # Add to the list of callbacks to call when a message is received
@@ -646,6 +647,7 @@ class Client:
         *,
         queue_class: type[asyncio.Queue[Message]] = asyncio.Queue,
         queue_maxsize: int = 0,
+        topic: str = None,
     ) -> tuple[Callable[[Message], None], AsyncGenerator[Message, None]]:
         # Queue to hold the incoming messages
         messages: asyncio.Queue[Message] = queue_class(maxsize=queue_maxsize)
@@ -653,7 +655,11 @@ class Client:
         def _callback(message: Message) -> None:
             """Put the new message in the queue."""
             try:
-                messages.put_nowait(message)
+                if topic:
+                    if message.topic.matches(topic):
+                        messages.put_nowait(message)
+                else:
+                    messages.put_nowait(message)
             except asyncio.QueueFull:
                 self._logger.warning("Message queue is full. Discarding message.")
 

--- a/aiomqtt/client.py
+++ b/aiomqtt/client.py
@@ -571,7 +571,7 @@ class Client:
         *,
         queue_class: type[asyncio.Queue[Message]] = asyncio.Queue,
         queue_maxsize: int = 0,
-        topic: str = None,
+        topic: str | None = None,
     ) -> AsyncGenerator[AsyncGenerator[Message, None], None]:
         """Return async generator of incoming messages.
 
@@ -647,7 +647,7 @@ class Client:
         *,
         queue_class: type[asyncio.Queue[Message]] = asyncio.Queue,
         queue_maxsize: int = 0,
-        topic: str = None,
+        topic: str | None = None,
     ) -> tuple[Callable[[Message], None], AsyncGenerator[Message, None]]:
         # Queue to hold the incoming messages
         messages: asyncio.Queue[Message] = queue_class(maxsize=queue_maxsize)


### PR DESCRIPTION
Add a topic optional parameter to messages, so that each queue only receives messages of the corresponding topic.


This is the case where topic is not used, it is the same as before:
```py
import asyncio
import aiomqtt


async def fast_consumer(client: aiomqtt.Client):
    async with client.messages() as messages:
        await client.subscribe("counter_example/#")
        async for message in messages:
            print(f"Fast consumer received: {message.payload}")


async def slow_consumer(client: aiomqtt.Client):
        async with client.messages() as messages:
            await client.subscribe("qwer/#")
            async for message in messages:
                print(f"Slow consumer received: {message.payload}")


async def producer(client: aiomqtt.Client):
    await client.publish("counter_example/int", "counter_example")
    await client.publish("qwer/int", "qwer")


async def main():
    async with aiomqtt.Client("test.mosquitto.org") as client:
        tasks = [
            asyncio.create_task(fast_consumer(client)),
            asyncio.create_task(slow_consumer(client)),
            asyncio.create_task(producer(client))]
        await asyncio.gather(*tasks)


asyncio.run(main())

```
Output:
```sh
Fast consumer received: b'counter_example'
Slow consumer received: b'counter_example'
Fast consumer received: b'qwer'
Slow consumer received: b'qwer'
```

This is the case where topic is used:
```py
import asyncio
import aiomqtt


async def fast_consumer(client: aiomqtt.Client):
    async with client.messages(topic="counter_example/#") as messages:
        await client.subscribe("counter_example/#")
        async for message in messages:
            print(f"Fast consumer received: {message.payload}")


async def slow_consumer(client: aiomqtt.Client):
        async with client.messages(topic="qwer/#") as messages:
            await client.subscribe("qwer/#")
            async for message in messages:
                print(f"Slow consumer received: {message.payload}")


async def producer(client: aiomqtt.Client):
    await client.publish("counter_example/int", "counter_example")
    await client.publish("qwer/int", "qwer")


async def main():
    async with aiomqtt.Client("test.mosquitto.org") as client:
        tasks = [
            asyncio.create_task(fast_consumer(client)),
            asyncio.create_task(slow_consumer(client)),
            asyncio.create_task(producer(client))]
        await asyncio.gather(*tasks)


asyncio.run(main())
```
Output:
```sh
Fast consumer received: b'counter_example'
Slow consumer received: b'qwer'
```

I thought it would be better than matching after receiving the message before.