### PR TITLE
Add reference section to docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,11 +5,13 @@ on:
     branches: [main]
     paths:
       - "docs/**"
+      - "aiomqtt/**"
       - README.md
       - .github/workflows/docs.yml
   pull_request:
     paths:
       - "docs/**"
+      - "aiomqtt/**"
       - README.md
       - .github/workflows/docs.yml
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,9 @@ We're very happy about contributions to aiomqtt! ✨
 
 ## The documentation
 
-The documentation uses [Sphinx](https://www.sphinx-doc.org/en/master/). The Markdown source files are located in the `docs` folder. You can build the documentation with `./scripts/docs --reload`.
+The documentation uses [Sphinx](https://www.sphinx-doc.org/en/master/). You can build it with `./scripts/docs --reload`.
+
+The Markdown source files are located in the `docs` folder. The reference section is mostly generated from the docstrings in the source code. The docstrings are formatted according to the [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings).
 
 ## Making a pull request
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-We're very happy about contributions to aiomqtt!
+We're very happy about contributions to aiomqtt! ✨
 
 ## Development setup
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Note that the underlying paho-mqtt library is dual-licensed. One of the licenses
 
 ## Contributing
 
-We're very happy about contributions to the project! You can get started by reading the [CONTRIBUTING.md](https://github.com/sbtinstruments/aiomqtt/blob/main/CONTRIBUTING.md) guide.
+We're very happy about contributions to the project! You can get started by reading [CONTRIBUTING.md](https://github.com/sbtinstruments/aiomqtt/blob/main/CONTRIBUTING.md).
 
 ## Versioning
 

--- a/aiomqtt/client.py
+++ b/aiomqtt/client.py
@@ -242,6 +242,13 @@ class Message:
 
 
 class Client:
+    """The async context manager that manages the connection to the broker.
+
+    Args:
+        hostname: The hostname or IP address of the remote broker
+        port: The network port of the remote broker
+    """
+
     def __init__(  # noqa: C901, PLR0912, PLR0913, PLR0915
         self,
         hostname: str,
@@ -899,7 +906,7 @@ class Client:
         exc: BaseException | None,
         tb: TracebackType | None,
     ) -> None:
-        # Try to gracefully disconnect from the broker
+        """Try to gracefully disconnect from the broker."""
         try:
             await self.disconnect()
         except MqttError as error:

--- a/aiomqtt/client.py
+++ b/aiomqtt/client.py
@@ -553,9 +553,14 @@ class Client:
             topic: The topic or wildcard to subscribe to.
             qos: The requested QoS level for the subscription.
             options: (MQTT v5.0 only) Optional paho-mqtt subscription options.
-            porperties: (MQTT v5.0 only) Optional paho-mqtt properties.
+            properties: (MQTT v5.0 only) Optional paho-mqtt properties.
+            *args: Additional positional arguments to pass to paho-mqtt's subscribe
+                method.
             timeout: The maximum time in seconds to wait for the subscription to
                 complete. Use ``math.inf`` to wait indefinitely.
+            **kwargs: Additional keyword arguments to pass to paho-mqtt's subscribe
+                method.
+
         """
         result, mid = self._client.subscribe(
             topic, qos, options, properties, *args, **kwargs
@@ -585,8 +590,12 @@ class Client:
         Args:
             topic: The topic or wildcard to unsubscribe from.
             properties: (MQTT v5.0 only) Optional paho-mqtt properties.
+            *args: Additional positional arguments to pass to paho-mqtt's unsubscribe
+                method.
             timeout: The maximum time in seconds to wait for the unsubscription to
                 complete. Use ``math.inf`` to wait indefinitely.
+            **kwargs: Additional keyword arguments to pass to paho-mqtt's unsubscribe
+                method.
         """
         result, mid = self._client.unsubscribe(topic, properties, *args, **kwargs)
         # Early out on error
@@ -618,8 +627,12 @@ class Client:
             qos: The QoS level to use for publication.
             retain: If set to ``True``, the message will be retained by the broker.
             properties: (MQTT v5.0 only) Optional paho-mqtt properties.
+            *args: Additional positional arguments to pass to paho-mqtt's publish
+                method.
             timeout: The maximum time in seconds to wait for publication to complete.
                 Use ``math.inf`` to wait indefinitely.
+            **kwargs: Additional keyword arguments to pass to paho-mqtt's publish
+                method.
         """
         info = self._client.publish(
             topic, payload, qos, retain, properties, *args, **kwargs

--- a/docs/alongside-fastapi-and-co.md
+++ b/docs/alongside-fastapi-and-co.md
@@ -1,4 +1,4 @@
-# Side by side with web frameworks
+# Alongside FastAPI & Co.
 
 MQTT is often used in the context of web servers.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,13 +13,14 @@ author = "Frederik Aalund, Felix Böhm, Jonathan Plasse"
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ["myst_parser", "sphinx_copybutton"]
+extensions = ["myst_parser", "sphinx_copybutton", "sphinx.ext.napoleon"]
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 pygments_style = "default"
 pygments_dark_style = "dracula"
 myst_enable_extensions = ["strikethrough"]
 myst_heading_anchors = 2
+autodoc_default_options = {"member-order": "bysource"}
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/docs/connecting-to-the-broker.md
+++ b/docs/connecting-to-the-broker.md
@@ -1,6 +1,6 @@
 # Connecting to the broker
 
-To publish messages and subscribe to topics, we need to connect to a broker. A minimal working example that publishes a message to the `temperature/outside` topic looks like this:
+To publish messages and subscribe to topics, we need to connect to a broker. A minimal working example that connects to a broker and then publishes a message looks like this:
 
 ```python
 import asyncio
@@ -15,121 +15,30 @@ async def main():
 asyncio.run(main())
 ```
 
-The connection to the broker is managed by the `Client` context manager. Context managers handle all connection and disconnection logic for you. aiomqtt doesn't support manual connect and disconnect calls.
+The connection to the broker is managed by the `Client` context manager.
+
+This context manager connects to the broker when you enter the `with` statement and disconnects when you exit it again. Similar to e.g. the `with open(file)` context manager, this ensures that the teardown logic is always executed at least, and at most, once -- even in case of an exception.
+
+This way, there's no chance that connections are left open by mistake.
 
 ```{tip}
-The above example uses the public [mosquitto test broker](https://test.mosquitto.org/). You can connect to this broker without any credentials. Please use the mosquitto test broker in issues or discussions (if possible) to make it easier for others to run your code.
+If you're used to calling somthing like `connect` and `disconnect` explicitly, working with the client via a context manager might feel a bit strange at first. We will see many examples which will hopefully clear this up.
+
+In case your use case does not allow you to use a context manager, you can use the context manager's `__aenter__` and `__aexit__` methods directly, similar to something like `connect` and `disconnect`. Note that you loose the benefits of context managers in this case. We do not recommend this approach; It's a workaround and a bit tricky to get right.
 ```
-
-## The client in detail
-
-You can configure quite a few things when initializing the client. These are all the possible parameters together with their default values. See [paho-mqtt's documentation](https://github.com/eclipse/paho.mqtt.python) for more information about the individual parameters.
-
-```python
-import aiomqtt
-import paho.mqtt as mqtt
-
-
-aiomqtt.Client(
-    hostname="test.mosquitto.org",  # The only non-optional parameter
-    port=1883,
-    username=None,
-    password=None,
-    logger=None,
-    client_id=None,
-    tls_context=None,
-    tls_params=None,
-    proxy=None,
-    protocol=None,
-    will=None,
-    clean_session=None,
-    transport="tcp",
-    timeout=None,
-    keepalive=60,
-    bind_address="",
-    bind_port=0,
-    clean_start=mqtt.client.MQTT_CLEAN_START_FIRST_ONLY,
-    properties=None,
-    message_retry_set=20,
-    socket_options=(),
-    max_concurrent_outgoing_calls=None,
-    websocket_path=None,
-    websocket_headers=None,
-    max_inflight_messages=None,
-    max_queued_messages=None,
-)
-```
-
-### Persistent sessions
-
-Connections to the MQTT broker can be persistent or non-persistent. Persistent sessions are kept alive when the client is offline. This means that the broker stores the client's subscriptions and queues any messages of [QoS 1 and 2](publishing-a-message.md#quality-of-service-qos) that the client misses or has not yet acknowledged. The broker will then retransmit the messages when the client reconnects.
-
-To create a persistent session, set the `clean_session` parameter to `False` when initializing the client. For a non-persistent session, set `clean_session` to `True`.
 
 ```{note}
-The amount of messages that can be queued is limited by the broker's memory. If a client with a persistent session does not come back online for a long time, the broker will eventually run out of memory and start discarding messages.
+Examples use the public [mosquitto test broker](https://test.mosquitto.org/). You can connect to this broker without any credentials. Please use the mosquitto test broker in issues or discussions (if possible) to make it easier for others to test your code.
 ```
 
-### TLS
-
-You can configure TLS via the `TLSParameters` class. The parameters are directly passed through to paho-mqtt's `tls_set` function. See [paho-mqtt's documentation](https://github.com/eclipse/paho.mqtt.python) for more information about the individual parameters.
-
-```python
-import asyncio
-import aiomqtt
-import ssl
-
-
-tls_params = aiomqtt.TLSParameters(
-    ca_certs=None,
-    certfile=None,
-    keyfile=None,
-    cert_reqs=ssl.CERT_REQUIRED,
-    tls_version=ssl.PROTOCOL_TLS,
-    ciphers=None,
-)
-
-
-async def main():
-    async with aiomqtt.Client("test.mosquitto.org", tls_params=tls_params) as client:
-        await client.publish("temperature/outside", payload=28.4)
-
-
-asyncio.run(main())
-```
-
-### Proxying
-
-You can configure proxying via the `ProxySettings` class. The parameters are directly passed through to paho-mqtt's `proxy_set` functionality. Both SOCKS and HTTP proxies are supported. Note that proxying is an extra feature (even in paho-mqtt) that requires the `PySocks` dependency. See [paho-mqtt's documentation](https://github.com/eclipse/paho.mqtt.python) for more information about the individual parameters.
-
-```python
-import asyncio
-import aiomqtt
-import socks
-
-
-proxy_params = aiomqtt.ProxySettings(
-    proxy_type=socks.HTTP,
-    proxy_addr="www.example.com",
-    proxy_rdns=True,
-    proxy_username=None,
-    proxy_password=None,
-)
-
-async def main():
-    async with aiomqtt.Client("test.mosquitto.org", proxy=proxy_params) as client:
-        await client.publish("temperature/outside", payload=28.4)
-
-
-asyncio.run(main())
-```
+For a list of all available arguments to the client, see the [API reference](#developer-interface).
 
 ## Sharing the connection
 
 In many cases, you'll want to send and receive messages in different locations in your code. You could create a new client each time, but:
 
-1. this is not very performant, and
-2. you'll use more network bandwidth.
+1. This is not very performant, and
+2. You'll use more network bandwidth.
 
 You can share the connection by passing the `Client` instance to all functions that need it:
 
@@ -153,4 +62,14 @@ async def main():
 
 
 asyncio.run(main())
+```
+
+## Persistent sessions
+
+Connections to the MQTT broker can be persistent or non-persistent. Persistent sessions are kept alive when the client is offline. This means that the broker stores the client's subscriptions and queues any messages of [QoS 1 and 2](publishing-a-message.md#quality-of-service-qos) that the client misses or has not yet acknowledged. The broker will then retransmit the messages when the client reconnects.
+
+To create a persistent session, set the `clean_session` parameter to `False` when initializing the client. For a non-persistent session, set `clean_session` to `True`.
+
+```{note}
+The amount of messages that can be queued is limited by the broker's memory. If a client with a persistent session does not come back online for a long time, the broker will eventually run out of memory and start discarding messages.
 ```

--- a/docs/connecting-to-the-broker.md
+++ b/docs/connecting-to-the-broker.md
@@ -19,16 +19,14 @@ The connection to the broker is managed by the `Client` context manager.
 
 This context manager connects to the broker when you enter the `with` statement and disconnects when you exit it again. Similar to e.g. the `with open(file)` context manager, this ensures that the teardown logic is always executed at least, and at most, once -- even in case of an exception.
 
-This way, there's no chance that connections are left open by mistake.
-
 ```{tip}
-If you're used to calling somthing like `connect` and `disconnect` explicitly, working with the client via a context manager might feel a bit strange at first. We will see many examples which will hopefully clear this up.
+If you're used to calling something like `connect` and `disconnect` explicitly, working with the client via a context manager might feel a bit strange at first. We will see a few examples which will hopefully clear this up.
 
 In case your use case does not allow you to use a context manager, you can use the context manager's `__aenter__` and `__aexit__` methods directly, similar to something like `connect` and `disconnect`. Note that you loose the benefits of context managers in this case. We do not recommend this approach; It's a workaround and a bit tricky to get right.
 ```
 
 ```{note}
-Examples use the public [mosquitto test broker](https://test.mosquitto.org/). You can connect to this broker without any credentials. Please use the mosquitto test broker in issues or discussions (if possible) to make it easier for others to test your code.
+Examples use the public [mosquitto test broker](https://test.mosquitto.org/). You can connect to this broker without any credentials. Please use this broker in issues or discussions (if possible) to make it easier for others to test your code.
 ```
 
 For a list of all available arguments to the client, see the [API reference](#developer-interface).

--- a/docs/developer-interface.md
+++ b/docs/developer-interface.md
@@ -1,0 +1,34 @@
+# Developer interface
+
+## Client
+
+```{eval-rst}
+.. autoclass:: aiomqtt.Client
+    :noindex:
+    :members: subscribe, unsubscribe, publish, messages, __aenter__, __aexit__
+    :undoc-members:  # Remove when everything has docstrings
+```
+
+## Message
+
+```{eval-rst}
+.. autoclass:: aiomqtt.Message
+    :noindex:
+    :members:
+```
+
+## Topic
+
+```{eval-rst}
+.. autoclass:: aiomqtt.Topic
+    :noindex:
+    :members:
+```
+
+## Wildcard
+
+```{eval-rst}
+.. autoclass:: aiomqtt.Wildcard
+    :noindex:
+    :members:
+```

--- a/docs/developer-interface.md
+++ b/docs/developer-interface.md
@@ -6,7 +6,6 @@
 .. autoclass:: aiomqtt.Client
     :noindex:
     :members: subscribe, unsubscribe, publish, messages, __aenter__, __aexit__
-    :undoc-members:  # Remove when everything has docstrings
 ```
 
 ## Message

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,14 @@ connecting-to-the-broker
 publishing-a-message
 subscribing-to-a-topic
 reconnection
-side-by-side-with-web-frameworks
+alongside-fastapi-and-co
+```
+
+```{toctree}
+:caption: API reference
+:hidden:
+
+developer-interface
 ```
 
 ```{toctree}

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -4,6 +4,6 @@ This documentation aims to cover everything you need to know to use aiomqtt in y
 
 If you're new to MQTT, we recommend reading the [HiveMQ MQTT essentials](https://www.hivemq.com/mqtt-essentials/) guide. For asyncio, we recommend the [RealPython asyncio walkthrough](https://realpython.com/async-io-python/) as an introduction and the [official asyncio docs](https://docs.python.org/3/library/asyncio.html) as a reference.
 
-Especially first-time readers have a very valuable view of the documentation. You can spot ambiguities and unclear explanations that simply stay hidden from us maintainers! So if you find an error somewhere or you feel there's anything that can improve these docs, please don't hesitate to open an issue or a pull request on GitHub.
+Especially first-time readers have a very valuable view of the documentation. You can spot ambiguities and unclear explanations that simply stay hidden from us maintainers! If you find an error somewhere or if you feel there's anything that can improve these docs, you're a big help if you open an issue or a pull request on GitHub.
 
 Let's dive in! 🤿

--- a/docs/subscribing-to-a-topic.md
+++ b/docs/subscribing-to-a-topic.md
@@ -163,7 +163,7 @@ async def main():
 asyncio.run(main())
 ```
 
-In case task groups are not an option (e.g. because you run aiomqtt [side by side with a web framework](side-by-side-with-web-frameworks.md)) you can start the listener in a fire-and-forget way. The idea is to use asyncio's `create_task` but not `await` the created task:
+In case task groups are not an option (e.g. because you run aiomqtt [alongside a web framework](alongside-fastapi-and-co.md)) you can start the listener in a fire-and-forget way. The idea is to use asyncio's `create_task` but not `await` the created task:
 
 ```{caution}
 You need to be a bit careful with this approach. Exceptions raised in asyncio tasks are propagated only when we `await` the task. In this case, we explicitly don't.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ parametrize-names-type = "csv"
 ]
 
 [tool.ruff.pydocstyle] # https://github.com/charliermarsh/ruff#pydocstyle
-convention = "pep257"
+convention = "google"
 
 [tool.mypy] # https://mypy.readthedocs.io/en/latest/config_file.html
 python_version = "3.8"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,8 +1,8 @@
 # Development scripts
 
-- **`check`**: Format and lint the code with `black` and `ruff`; Use `--dry` option for dry run
-- **`docs`**: Build the documentation; Use `--reload` option to serve locally with live reload
-- **`setup`**: Setup or update the dependencies after a `git clone` or `git pull`
-- **`test`**: Run the tests
+- `check`: Format and lint the code with `black` and `ruff`; Use `--dry` option for dry run
+- `docs`: Build the documentation; Use `--reload` option to serve locally with live reload
+- `setup`: Setup or update the dependencies after a `git clone` or `git pull`
+- `test`: Run the tests
 
-Styled after GitHub's [Scripts to Rule Them All](https://github.com/github/scripts-to-rule-them-all).
+Styled after GitHub's ["Scripts to Rule Them All"](https://github.com/github/scripts-to-rule-them-all).

--- a/scripts/docs
+++ b/scripts/docs
@@ -26,7 +26,7 @@ done
 
 # Serve the documentation
 if [ "${reload}" = true ]; then
-  poetry run sphinx-autobuild --port 8145 --open-browser docs docs/_build
+  poetry run sphinx-autobuild --open-browser --delay 0 --port 8145 docs docs/_build
 else
   poetry run sphinx-build -b html docs docs/_build
 fi


### PR DESCRIPTION
I added Google-style docstrings to most of the classes to autogenerate a reference section in the docs (+ some smaller documentation tweaks). You can preview the docs as usual with `./scripts/setup && ./scripts/docs --reload`. Happy to hear what you think!