### PR TITLE
don't suppress exception on aexit

### DIFF
--- a/aiomqtt/client.py
+++ b/aiomqtt/client.py
@@ -514,7 +514,8 @@ class Client:
     def _early_out_on_disconnected(self)-> bool:
          # Early out if already disconnected...
         if self._disconnected.done():
-            if (disc_exc:= self._disconnected.exception()) is not None:
+            disc_exc = self._disconnected.exception()
+            if disc_exc is not None:
                 # ...by raising the error that caused the disconnect
                 raise disc_exc
             # ...by returning since the disconnect was intentional

--- a/aiomqtt/client.py
+++ b/aiomqtt/client.py
@@ -511,8 +511,8 @@ class Client:
         if self._disconnected.done():
             self._disconnected = asyncio.Future()
 
-    def _early_out_on_disconnected(self)-> bool:
-         # Early out if already disconnected...
+    def _early_out_on_disconnected(self) -> bool:
+        # Early out if already disconnected...
         if self._disconnected.done():
             disc_exc = self._disconnected.exception()
             if disc_exc is not None:


### PR DESCRIPTION
With #216 the "early out on disconnected" code was move from the function `__aexit__` to `disconnect`. The `disconnect` function is called inside a try/except block in the function `__aexit__`, which suppresses the disconnected exception. This results in that the context manager exits without exception also when there was a disconnect-exception.

Example:
- start mqtt broker
- run a similar code:
```python
async with Client("localhost") as client:
    async with client.messages() as messages:
        await client.subscribe("humidity/#")
        async for message in messages:
            print(message.payload)
```
- shutdown broker

expection: I get some sort of exception
actual: no exception, only a log entry.

This bug was found on the upgrade from `0.16.1` to `1.0.0`. Afterwards the following test was failing https://github.com/DeebotUniverse/client.py/blob/3d7467e3dcf338e9d848dd5fb3ad32a5ee7fab8e/tests/test_mqtt_client.py#L76C1-L76C1
The test test the described example above.