### PR TITLE
release lock only if acquired

### DIFF
--- a/aiomqtt/client.py
+++ b/aiomqtt/client.py
@@ -1066,7 +1066,8 @@ class Client:
                 )
         finally:
             self._force_disconnect()
-            self._lock.release()
+            if self._lock.locked():
+                self._lock.release()
 
 
 def _set_client_socket_defaults(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -87,6 +87,12 @@ async def test_topic_matches() -> None:
     assert not topic.matches("$test/group/a/b/c")
 
 
+async def test__aexit__():
+    """Test that it's possible to call __aexit__ without __aenter__, e.g. in case of unsucessful __aenter__"""
+    client = Client(HOSTNAME)
+    await client.__aexit__(None, None, None)
+
+
 @pytest.mark.network
 async def test_multiple_messages_generators() -> None:
     """Test that multiple Client.messages() generators can be used at the same time."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -87,8 +87,11 @@ async def test_topic_matches() -> None:
     assert not topic.matches("$test/group/a/b/c")
 
 
-async def test__aexit__():
-    """Test that it's possible to call __aexit__ without __aenter__, e.g. in case of unsucessful __aenter__"""
+async def test__aexit__() -> None:
+    """Test that it's possible to call __aexit__ without prior __aenter__.
+
+    This should also cover the case of an unsucessful __aenter__.
+    """
     client = Client(HOSTNAME)
     await client.__aexit__(None, None, None)
 


### PR DESCRIPTION
If connection fails calling `__aexit__` will result in an Lock-exception.
This small check prevents that