### PR TITLE
[WIP] transition to anyio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ aiomqtt/_version.py
 *.DS_Store
 docs/_build
 reports
+
+# Debian packaging
+/debian/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">The idiomatic asyncio MQTT client 🙌</h1>
+<h1 align="center">The idiomatic async MQTT client 🙌</h1>
 <p align="center"><em>(formerly known as asyncio-mqtt)</em></p>
 <p align="center">
     <a href="https://github.com/sbtinstruments/aiomqtt/blob/main/LICENSE"><img alt="License: BSD-3-Clause" src="https://img.shields.io/github/license/sbtinstruments/aiomqtt"></a>
@@ -33,7 +33,7 @@ async with Client("test.mosquitto.org") as client:
         print(message.payload)
 ```
 
-aiomqtt combines the stability of the time-proven [paho-mqtt](https://github.com/eclipse/paho.mqtt.python) library with an idiomatic asyncio interface:
+aiomqtt combines the stability of the time-proven [paho-mqtt](https://github.com/eclipse/paho.mqtt.python) library with an idiomatic async interface:
 
 - No more callbacks! 👍
 - No more return codes (welcome to the `MqttError`)
@@ -41,6 +41,7 @@ aiomqtt combines the stability of the time-proven [paho-mqtt](https://github.com
 - Supports MQTT versions 5.0, 3.1.1 and 3.1
 - Fully type-hinted
 - Did we mention no more callbacks?
+- Works with asyncio *and* trio! No workarounds requires!
 
 <!-- pitch end -->
 
@@ -59,19 +60,6 @@ aiomqtt can be installed via `pip install aiomqtt`. The only dependency is [paho
 If you can't wait for the latest version, you can install aiomqtt directly from GitHub with:
 
 `pip install git+https://github.com/sbtinstruments/aiomqtt`
-
-### Note for Windows users
-
-Since Python `3.8`, the default asyncio event loop is the `ProactorEventLoop`. Said loop [doesn't support the `add_reader` method](https://docs.python.org/3/library/asyncio-platforms.html#windows) that is required by aiomqtt. Please switch to an event loop that supports the `add_reader` method such as the built-in `SelectorEventLoop`:
-
-```python
-# Change to the "Selector" event loop if platform is Windows
-if sys.platform.lower() == "win32" or os.name.lower() == "nt":
-    from asyncio import set_event_loop_policy, WindowsSelectorEventLoopPolicy
-    set_event_loop_policy(WindowsSelectorEventLoopPolicy())
-# Run your async application as usual
-asyncio.run(main())
-```
 
 ## License
 

--- a/aiomqtt/client.py
+++ b/aiomqtt/client.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
-import asyncio
-import contextlib
+import anyio
+from contextlib import contextmanager, asynccontextmanager
 import dataclasses
 import enum
 import functools
@@ -26,8 +26,9 @@ from typing import (
     cast,
 )
 
-import paho.mqtt.client as mqtt
-from paho.mqtt.enums import CallbackAPIVersion
+from . import paho as mqtt
+from paho.mqtt.client import MQTT_CLEAN_START_FIRST_ONLY
+from paho.mqtt.enums import CallbackAPIVersion, ConnackCode, MQTTProtocolVersion, MQTTErrorCode
 from paho.mqtt.properties import Properties
 from paho.mqtt.reasoncodes import ReasonCode
 from paho.mqtt.subscribeoptions import SubscribeOptions
@@ -43,6 +44,8 @@ from .types import (
     WebSocketHeaders,
     _PahoSocket,
 )
+from .queue import Queue
+from .event import ValueEvent
 
 if sys.version_info >= (3, 11):
     from typing import Concatenate, Self
@@ -63,9 +66,9 @@ ClientT = TypeVar("ClientT", bound="Client")
 class ProtocolVersion(enum.IntEnum):
     """Map paho-mqtt protocol versions to an Enum for use in type hints."""
 
-    V31 = mqtt.MQTTv31
-    V311 = mqtt.MQTTv311
-    V5 = mqtt.MQTTv5
+    V31 = MQTTProtocolVersion.MQTTv31
+    V311 = MQTTProtocolVersion.MQTTv311
+    V5 = MQTTProtocolVersion.MQTTv5
 
 
 @dataclasses.dataclass(frozen=True)
@@ -134,10 +137,7 @@ class Client:
         password: The password to authenticate with.
         logger: Custom logger instance.
         identifier: The client identifier. Generated automatically if ``None``.
-        queue_type: The class to use for the queue. The default is
-            ``asyncio.Queue``, which stores messages in FIFO order. For LIFO order,
-            you can use ``asyncio.LifoQueue``; For priority order you can subclass
-            ``asyncio.PriorityQueue``.
+        queue_type: The class to use for the queue.
         protocol: The version of the MQTT protocol.
         will: The will message to publish if the client disconnects unexpectedly.
         clean_session: If ``True``, the broker will remove all information about this
@@ -186,7 +186,7 @@ class Client:
         password: str | None = None,
         logger: logging.Logger | None = None,
         identifier: str | None = None,
-        queue_type: type[asyncio.Queue[Message]] | None = None,
+        queue_type: type[Queue[Message]] | None = None,
         protocol: ProtocolVersion | None = None,
         will: Will | None = None,
         clean_session: bool | None = None,
@@ -195,7 +195,7 @@ class Client:
         keepalive: int = 60,
         bind_address: str = "",
         bind_port: int = 0,
-        clean_start: mqtt.CleanStartOption = mqtt.MQTT_CLEAN_START_FIRST_ONLY,
+        clean_start: mqtt.CleanStartOption = MQTT_CLEAN_START_FIRST_ONLY,
         max_queued_incoming_messages: int | None = None,
         max_queued_outgoing_messages: int | None = None,
         max_inflight_messages: int | None = None,
@@ -216,34 +216,30 @@ class Client:
         self._bind_port = bind_port
         self._clean_start = clean_start
         self._properties = properties
-        self._loop = asyncio.get_event_loop()
 
         # Connection state
-        self._connected: asyncio.Future[None] = asyncio.Future()
-        self._disconnected: asyncio.Future[None] = asyncio.Future()
-        self._lock: asyncio.Lock = asyncio.Lock()
+        self._connected: ValueEvent = ValueEvent()
+        self._disconnected: ValueEvent = ValueEvent()
 
         # Pending subscribe, unsubscribe, and publish calls
         self._pending_subscribes: dict[
-            int, asyncio.Future[tuple[int, ...] | list[ReasonCode]]
+            int, ValueEvent[ReasonCode]
         ] = {}
-        self._pending_unsubscribes: dict[int, asyncio.Event] = {}
-        self._pending_publishes: dict[int, asyncio.Event] = {}
+        self._pending_unsubscribes: dict[int, Event] = {}
+        self._pending_publishes: dict[int, Event] = {}
         self.pending_calls_threshold: int = 10
-        self._misc_task: asyncio.Task[None] | None = None
 
         # Queue that holds incoming messages
         if queue_type is None:
-            queue_type = cast("type[asyncio.Queue[Message]]", asyncio.Queue)
+            queue_type = Queue
         if max_queued_incoming_messages is None:
             max_queued_incoming_messages = 0
-        self._queue = queue_type(maxsize=max_queued_incoming_messages)
-        self.messages = self._messages()
+        self._queue = queue_type(max_queued_incoming_messages)
 
         # Semaphore to limit the number of concurrent outgoing calls
-        self._outgoing_calls_sem: asyncio.Semaphore | None
+        self._outgoing_calls_sem: anyio.Semaphore | None
         if max_concurrent_outgoing_calls is not None:
-            self._outgoing_calls_sem = asyncio.Semaphore(max_concurrent_outgoing_calls)
+            self._outgoing_calls_sem = anyio.Semaphore(max_concurrent_outgoing_calls)
         else:
             self._outgoing_calls_sem = None
 
@@ -252,7 +248,7 @@ class Client:
 
         # Create the underlying paho-mqtt client instance
         self._client: mqtt.Client = mqtt.Client(
-            callback_api_version=CallbackAPIVersion.VERSION1,
+            callback_api_version=CallbackAPIVersion.VERSION2,
             client_id=identifier,  # type: ignore[arg-type]
             protocol=protocol,
             clean_session=clean_session,
@@ -265,12 +261,6 @@ class Client:
         self._client.on_unsubscribe = self._on_unsubscribe
         self._client.on_message = self._on_message
         self._client.on_publish = self._on_publish
-
-        # Callbacks for custom event loop
-        self._client.on_socket_open = self._on_socket_open
-        self._client.on_socket_close = self._on_socket_close
-        self._client.on_socket_register_write = self._on_socket_register_write
-        self._client.on_socket_unregister_write = self._on_socket_unregister_write
 
         if max_inflight_messages is not None:
             self._client.max_inflight_messages_set(max_inflight_messages)
@@ -346,7 +336,6 @@ class Client:
         options: SubscribeOptions | None = None,
         properties: Properties | None = None,
         *args: Any,
-        timeout: float | None = None,
         **kwargs: Any,
     ) -> tuple[int, ...] | list[ReasonCode]:
         """Subscribe to a topic or wildcard.
@@ -358,8 +347,6 @@ class Client:
             properties: (MQTT v5.0 only) Optional paho-mqtt properties.
             *args: Additional positional arguments to pass to paho-mqtt's subscribe
                 method.
-            timeout: The maximum time in seconds to wait for the subscription to
-                complete. Use ``math.inf`` to wait indefinitely.
             **kwargs: Additional keyword arguments to pass to paho-mqtt's subscribe
                 method.
 
@@ -368,15 +355,14 @@ class Client:
             topic, qos, options, properties, *args, **kwargs
         )
         # Early out on error
-        if result != mqtt.MQTT_ERR_SUCCESS or mid is None:
+        if result != MQTTErrorCode.MQTT_ERR_SUCCESS or mid is None:
             raise MqttCodeError(result, "Could not subscribe to topic")
+
         # Create future for when the on_subscribe callback is called
-        callback_result: asyncio.Future[
-            tuple[int, ...] | list[ReasonCode]
-        ] = asyncio.Future()
+        callback_result = ValueEvent()
         with self._pending_call(mid, callback_result, self._pending_subscribes):
             # Wait for callback_result
-            return await self._wait_for(callback_result, timeout=timeout)
+            return await callback_result.wait()
 
     @_outgoing_call
     async def unsubscribe(
@@ -385,7 +371,6 @@ class Client:
         topic: str | list[str],
         properties: Properties | None = None,
         *args: Any,
-        timeout: float | None = None,
         **kwargs: Any,
     ) -> None:
         """Unsubscribe from a topic or wildcard.
@@ -395,20 +380,18 @@ class Client:
             properties: (MQTT v5.0 only) Optional paho-mqtt properties.
             *args: Additional positional arguments to pass to paho-mqtt's unsubscribe
                 method.
-            timeout: The maximum time in seconds to wait for the unsubscription to
-                complete. Use ``math.inf`` to wait indefinitely.
             **kwargs: Additional keyword arguments to pass to paho-mqtt's unsubscribe
                 method.
         """
         result, mid = self._client.unsubscribe(topic, properties, *args, **kwargs)  # type: ignore[arg-type]
         # Early out on error
-        if result != mqtt.MQTT_ERR_SUCCESS or mid is None:
+        if result != MQTTErrorCode.MQTT_ERR_SUCCESS or mid is None:
             raise MqttCodeError(result, "Could not unsubscribe from topic")
         # Create event for when the on_unsubscribe callback is called
-        confirmation = asyncio.Event()
+        confirmation = anyio.Event()
         with self._pending_call(mid, confirmation, self._pending_unsubscribes):
             # Wait for confirmation
-            await self._wait_for(confirmation.wait(), timeout=timeout)
+            await confirmation.wait()
 
     @_outgoing_call
     async def publish(  # noqa: PLR0913
@@ -420,7 +403,6 @@ class Client:
         retain: bool = False,
         properties: Properties | None = None,
         *args: Any,
-        timeout: float | None = None,
         **kwargs: Any,
     ) -> None:
         """Publish a message to the broker.
@@ -433,66 +415,32 @@ class Client:
             properties: (MQTT v5.0 only) Optional paho-mqtt properties.
             *args: Additional positional arguments to pass to paho-mqtt's publish
                 method.
-            timeout: The maximum time in seconds to wait for publication to complete.
-                Use ``math.inf`` to wait indefinitely.
             **kwargs: Additional keyword arguments to pass to paho-mqtt's publish
                 method.
         """
+        # There may be no `await` before the one that awaits confirmation
         info = self._client.publish(
             topic, payload, qos, retain, properties, *args, **kwargs
-        )  # [2]
+        )
         # Early out on error
-        if info.rc != mqtt.MQTT_ERR_SUCCESS:
+        if info.rc != MQTTErrorCode.MQTT_ERR_SUCCESS:
             raise MqttCodeError(info.rc, "Could not publish message")
         # Early out on immediate success
         if info.is_published():
             return
         # Create event for when the on_publish callback is called
-        confirmation = asyncio.Event()
+        confirmation = anyio.Event()
         with self._pending_call(info.mid, confirmation, self._pending_publishes):
             # Wait for confirmation
-            await self._wait_for(confirmation.wait(), timeout=timeout)
+            await confirmation.wait()
 
-    async def _messages(self) -> AsyncGenerator[Message, None]:
+    @property
+    async def messages(self) -> AsyncGenerator[Message, None]:
         """Async generator that yields messages from the underlying message queue."""
         while True:
-            # Wait until we either:
-            #  1. Receive a message
-            #  2. Disconnect from the broker
-            task = self._loop.create_task(self._queue.get())
-            try:
-                done, _ = await asyncio.wait(
-                    (task, self._disconnected), return_when=asyncio.FIRST_COMPLETED
-                )
-            except asyncio.CancelledError:
-                # If the asyncio.wait is cancelled, we must make sure
-                # to also cancel the underlying tasks.
-                task.cancel()
-                raise
-            if task in done:
-                # We received a message. Return the result.
-                yield task.result()
-            else:
-                # We were disconnected from the broker
-                task.cancel()
-                # Stop the generator with an exception
-                msg = "Disconnected during message iteration"
-                raise MqttError(msg)
+            yield await self._queue.get()
 
-    async def _wait_for(
-        self, fut: Awaitable[T], timeout: float | None, **kwargs: Any
-    ) -> T:
-        if timeout is None:
-            timeout = self.timeout
-        # Note that asyncio uses `None` to mean "No timeout". We use `math.inf`.
-        timeout_for_asyncio = None if timeout == math.inf else timeout
-        try:
-            return await asyncio.wait_for(fut, timeout=timeout_for_asyncio, **kwargs)
-        except asyncio.TimeoutError:
-            msg = "Operation timed out"
-            raise MqttError(msg) from None
-
-    @contextlib.contextmanager
+    @contextmanager
     def _pending_call(
         self, mid: int, value: T, pending_dict: dict[int, T]
     ) -> Iterator[None]:
@@ -524,52 +472,44 @@ class Client:
         client: mqtt.Client,
         userdata: Any,
         flags: dict[str, int],
-        rc: int | ReasonCode,
+        rc: ReasonCode,
         properties: Properties | None = None,
     ) -> None:
         """Called when we receive a CONNACK message from the broker."""
         # Return early if already connected. Sometimes, paho-mqtt calls _on_connect
         # multiple times. Maybe because we receive multiple CONNACK messages
         # from the server. In any case, we return early so that we don't set
-        # self._connected twice (as it raises an asyncio.InvalidStateError).
-        if self._connected.done():
+        # self._connected twice
+        if self._connected.is_set():
             return
-        if rc == mqtt.CONNACK_ACCEPTED:
-            self._connected.set_result(None)
+        if rc.value < 6:
+            self._connected.set(None)
         else:
             # We received a negative CONNACK response
-            self._connected.set_exception(MqttConnectError(rc))
+            self._connected.set_error(MqttConnectError(rc))
 
     def _on_disconnect(
         self,
         client: mqtt.Client,
         userdata: Any,
-        rc: int | ReasonCode | None,
+        flags: int,
+        rc: ReasonCode | None,
         properties: Properties | None = None,
     ) -> None:
         # Return early if the disconnect is already acknowledged.
         # Sometimes (e.g., due to timeouts), paho-mqtt calls _on_disconnect
         # twice. We return early to avoid setting self._disconnected twice
-        # (as it raises an asyncio.InvalidStateError).
-        if self._disconnected.done():
+        if self._disconnected.is_set():
             return
-        # Return early if we are not connected yet. This avoids calling
-        # `_disconnected.set_exception` with an exception that will never
-        # be retrieved (since `__aexit__` won't get called if `__aenter__`
-        # fails). In turn, this avoids asyncio debug messages like the
-        # following:
-        #
-        #   `[asyncio] Future exception was never retrieved`
-        #
-        # See also: https://docs.python.org/3/library/asyncio-dev.html#detect-never-retrieved-exceptions
-        if not self._connected.done() or self._connected.exception() is not None:
-            return
-        if rc == mqtt.MQTT_ERR_SUCCESS:
-            self._disconnected.set_result(None)
+
+        if rc is None or rc.value < 6:
+            self._disconnected.set(None)
         else:
-            self._disconnected.set_exception(
+            self._disconnected.set_error(
                 MqttCodeError(rc, "Unexpected disconnection")
             )
+
+        self._connected = ValueEvent()
 
     def _on_subscribe(  # noqa: PLR0913
         self,
@@ -582,8 +522,7 @@ class Client:
         """Called when we receive a SUBACK message from the broker."""
         try:
             fut = self._pending_subscribes.pop(mid)
-            if not fut.done():
-                fut.set_result(granted_qos)
+            fut.set(granted_qos)
         except KeyError:
             self._logger.exception(
                 'Unexpected message ID "%d" in on_subscribe callback', mid
@@ -613,10 +552,11 @@ class Client:
         # Put the message in the message queue
         try:
             self._queue.put_nowait(m)
-        except asyncio.QueueFull:
+        except anyio.WouldBlock:
             self._logger.warning("Message queue is full. Discarding message.")
 
-    def _on_publish(self, client: mqtt.Client, userdata: Any, mid: int) -> None:
+    def _on_publish(self, client: mqtt.Client, userdata: Any, mid: int, 
+            reason: ReasonCode, props: Properties) -> None:
         try:
             self._pending_publishes.pop(mid).set()
         except KeyError:
@@ -625,136 +565,69 @@ class Client:
             # chance to set up the 'pending_call' logic.
             pass
 
-    def _on_socket_open(
-        self, client: mqtt.Client, userdata: Any, sock: _PahoSocket
-    ) -> None:
-        def callback() -> None:
-            # client.loop_read() may raise an exception, such as BadPipe. It's
-            # usually a sign that the underlaying connection broke, therefore we
-            # disconnect straight away
-            try:
-                client.loop_read()
-            except Exception as exc:
-                if not self._disconnected.done():
-                    self._disconnected.set_exception(exc)
+    __ctx = None
 
-        # paho-mqtt calls this function from the executor thread on which we've called
-        # `self._client.connect()` (see [3]), so we can't do most operations on
-        # self._loop directly.
-        def create_misc_task() -> None:
-            self._misc_task = self._loop.create_task(self._misc_loop())
+    async def __aenter__(self):
+        if self.__ctx is not None:
+            raise MqttReentrantError
+        ctx = self._ctx()
+        res = await ctx.__aenter__()
+        self.__ctx = ctx
+        return res
 
-        self._loop.call_soon_threadsafe(self._loop.add_reader, sock.fileno(), callback)
-        self._loop.call_soon_threadsafe(create_misc_task)
-
-    def _on_socket_close(
-        self, client: mqtt.Client, userdata: Any, sock: _PahoSocket
-    ) -> None:
-        fileno = sock.fileno()
-        if fileno > -1:
-            self._loop.remove_reader(fileno)
-        if self._misc_task is not None and not self._misc_task.done():
-            self._loop.call_soon_threadsafe(self._misc_task.cancel)
-
-    def _on_socket_register_write(
-        self, client: mqtt.Client, userdata: Any, sock: _PahoSocket
-    ) -> None:
-        def callback() -> None:
-            # client.loop_write() may raise an exception, such as BadPipe. It's
-            # usually a sign that the underlaying connection broke, therefore we
-            # disconnect straight away
-            try:
-                client.loop_write()
-            except Exception as exc:
-                if not self._disconnected.done():
-                    self._disconnected.set_exception(exc)
-
-        # paho-mqtt may call this function from the executor thread on which we've called
-        # `self._client.connect()` (see [3]), so we can't do most operations on
-        # self._loop directly.
-        self._loop.call_soon_threadsafe(self._loop.add_writer, sock, callback)
-
-    def _on_socket_unregister_write(
-        self, client: mqtt.Client, userdata: Any, sock: _PahoSocket
-    ) -> None:
-        self._loop.remove_writer(sock)
-
-    async def _misc_loop(self) -> None:
-        while self._client.loop_misc() == mqtt.MQTT_ERR_SUCCESS:
-            await asyncio.sleep(1)
-
-    async def __aenter__(self) -> Self:
-        """Connect to the broker."""
-        if self._lock.locked():
-            msg = "The client context manager is reusable, but not reentrant"
-            raise MqttReentrantError(msg)
-        await self._lock.acquire()
+    def __aexit__(self, *tb):
         try:
-            loop = asyncio.get_running_loop()
-            # [3] Run connect() within an executor thread, since it blocks on socket
-            # connection for up to `keepalive` seconds: https://git.io/Jt5Yc
-            await loop.run_in_executor(
-                None,
-                self._client.connect,
-                self._hostname,
-                self._port,
-                self._keepalive,
-                self._bind_address,
-                self._bind_port,
-                self._clean_start,
-                self._properties,
-            )
-            _set_client_socket_defaults(self._client.socket(), self._socket_options)
-        # Convert all possible paho-mqtt Client.connect exceptions to our MqttError
-        # See: https://github.com/eclipse/paho.mqtt.python/blob/v1.5.0/src/paho/mqtt/client.py#L1770
-        except (OSError, mqtt.WebsocketConnectionError) as exc:
-            self._lock.release()
-            raise MqttError(str(exc)) from None
-        try:
-            await self._wait_for(self._connected, timeout=None)
-        except MqttError:
-            # Reset state if connection attempt times out or CONNACK returns negative
-            self._lock.release()
-            self._connected = asyncio.Future()
-            raise
-        # Reset `_disconnected` if it's already in completed state after connecting
-        if self._disconnected.done():
-            self._disconnected = asyncio.Future()
-        return self
+            return self.__ctx.__aexit__(*tb)
+        finally:
+            self.__ctx = None
 
-    async def __aexit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc: BaseException | None,
-        tb: TracebackType | None,
-    ) -> None:
-        """Disconnect from the broker."""
-        if self._disconnected.done():
-            # Return early if the client is already disconnected
-            if self._lock.locked():
-                self._lock.release()
-            if (exc := self._disconnected.exception()) is not None:
-                # If the disconnect wasn't intentional, raise the error that caused it
+    @asynccontextmanager
+    async def _ctx(self):
+        if self._disconnected.is_set():
+            self._disconnected = ValueEvent()
+        self._connected = ValueEvent()
+
+        exc = None
+        try:
+            with anyio.fail_after(self.timeout) as timer:
+                async with self._client.connect(
+                        self._hostname,
+                        self._port,
+                        self._keepalive,
+                        self._bind_address,
+                        self._bind_port,
+                        self._clean_start,
+                        self._properties,
+                        ):
+
+                    try:
+                        await self._connected.get()
+                    except Exception as err:
+                        exc = err
+                        raise
+
+                    timer.deadline = float('inf')
+                    yield self
+
+                    rc = self._client.disconnect()
+                    if rc == MQTTErrorCode.MQTT_ERR_SUCCESS:
+                        # Wait for acknowledgement
+                        await self._disconnected.get()
+
+        except ExceptionGroup as exc2:
+            # If the original error has been wrapped in an exception group,
+            # raise it instead.
+            # 
+            # This typically happens when the server closes the connection
+            # after sending an error. We thus get the MQTT error from the
+            # disconnect packet *and* the EOFError because it closed the
+            # connection.
+
+            if exc is not None:
                 raise exc
-            return
-        # Try to gracefully disconnect from the broker
-        rc = self._client.disconnect()
-        if rc == mqtt.MQTT_ERR_SUCCESS:
-            # Wait for acknowledgement
-            await self._wait_for(self._disconnected, timeout=None)
-            # Reset `_connected` if it's still in completed state after disconnecting
-            if self._connected.done():
-                self._connected = asyncio.Future()
-        else:
-            self._logger.warning(
-                "Could not gracefully disconnect: %d. Forcing disconnection.", rc
-            )
-        # Force disconnection if we cannot gracefully disconnect
-        if not self._disconnected.done():
-            self._disconnected.set_result(None)
-        # Release the reusability lock
-        if self._lock.locked():
-            self._lock.release()
+            raise
+
+
 
 
 def _set_client_socket_defaults(

--- a/aiomqtt/event.py
+++ b/aiomqtt/event.py
@@ -1,0 +1,76 @@
+"""
+This module contains an awaitable value.
+"""
+
+from __future__ import annotations
+
+import anyio
+from concurrent.futures import CancelledError
+
+import attr
+
+__all__ = ["ValueEvent"]
+
+
+@attr.s
+class ValueEvent:
+    """A waitable value useful for inter-task synchronization,
+    inspired by :class:`threading.Event`.
+
+    An event object manages an internal value, which is initially
+    unset, and a task can wait for it to become True.
+
+    Note that the value can only be set and read once.
+    """
+
+    event = attr.ib(factory=anyio.Event, init=False)
+    value = attr.ib(default=None, init=False)
+
+    def set(self, value):
+        """Set the result to return this value, and wake any waiting task."""
+        if self.value is not None:
+            raise RuntimeError("Already set")
+        self.value = value
+        self.event.set()
+
+    def set_error(self, exc):
+        """Set the result to raise this exceptio, and wake any waiting task."""
+        if self.value is not None:
+            raise RuntimeError("Already set")
+        self.value = exc
+        self.event.set()
+
+    def is_set(self):
+        """Check whether the event has occurred."""
+        return self.value is not None
+
+    def cancel(self):
+        """Send a cancelation to the recipient.
+
+        Note that this is a `concurrent.futures.CancelledError`,
+
+        not whatever the cancellation semantics of the current anyio
+        backend demands.
+        """
+        self.set_error(CancelledError())
+
+    async def wait(self):
+        """Block until the value is set.
+
+        If it's already set, then this method returns immediately.
+
+        The value is not (yet) read; if it's an error, it will not be raised from here.
+        """
+        await self.event.wait()
+
+    async def get(self):
+        """Block until the value is set.
+
+        If it's already set, then this method returns immediately.
+
+        The value can only be read once.
+        """
+        await self.event.wait()
+        if isinstance(self.value, Exception):
+            raise self.value
+        return self.value

--- a/aiomqtt/paho.py
+++ b/aiomqtt/paho.py
@@ -1,0 +1,595 @@
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+import anyio
+import anyio.streams.buffered
+import anyio.streams.stapled
+
+import logging
+import math
+import ssl
+import sys
+import time
+
+from contextlib import asynccontextmanager, nullcontext
+
+from typing import (
+    Any,
+    AsyncGenerator,
+    Awaitable,
+    Callable,
+    Coroutine,
+    Generator,
+    Iterable,
+    Iterator,
+    Literal,
+    TypeVar,
+    cast,
+)
+
+from contextlib import nullcontext
+
+import paho.mqtt.client as mqtt
+from paho.mqtt.enums import MQTTErrorCode, MessageType, CallbackAPIVersion, _ConnectionState
+from paho.mqtt.properties import Properties
+from paho.mqtt.reasoncodes import ReasonCode
+from paho.mqtt.packettypes import PacketTypes
+
+from .exceptions import MqttCodeError, MqttConnectError, MqttError
+from .event import ValueEvent
+from .queue import Queue
+
+if sys.version_info >= (3, 11):
+    from typing import Concatenate, Self
+elif sys.version_info >= (3, 10):
+    from typing import Concatenate
+
+    from typing_extensions import Self
+else:
+    from typing_extensions import Concatenate, Self
+
+_null_ctx = nullcontext()
+
+logger = logging.getLogger(__name__)
+
+try:
+    # Use monotonic clock if available
+    time_func = time.monotonic
+except AttributeError:
+    time_func = time.time
+
+class _UngroupExc:
+    """
+    A sync+async context manager that unwraps single-element
+    exception groups.
+    """
+    def __call__(self):
+        "Singleton. Returns itself."
+        return self
+
+    def one(self, e):
+        "convert the exceptiongroup @e to a single exception"
+        while isinstance(e, BaseExceptionGroup):
+            if len(e.exceptions) != 1:
+                break
+            e = e.exceptions[0]
+        return e
+
+    def __enter__(self):
+        return self
+
+    async def __aenter__(self):
+        return self
+
+    def __exit__(self, c, e, t):
+        if e is None:
+            return
+        e = self.one(e)
+        raise e
+
+    async def __aexit__(self, c, e, t):
+        return self.__exit__(c, e, t)
+
+ungroup_exc = _UngroupExc()
+
+
+class MQTTMessageInfo(mqtt.MQTTMessageInfo):
+    __slots__ = 'mid', '_published', '_condition', 'rc', '_iterpos', '_event'
+
+
+    def __init__(self, mid:int):
+        self.mid = mid
+        self._published = False
+        self._condition = _null_ctx
+        self._event = anyio.Event()
+        self._iterpos = 0
+
+    async def wait(self):
+        await self._event.wait()
+
+    def wait_for_publish(self, timeout=None):
+        raise RuntimeError("Superseded")
+
+    def _set_as_published(self) -> None:
+        self._published = True
+        self._event.set()
+
+mqtt.MQTTMessageInfo = MQTTMessageInfo
+
+
+class Client(mqtt.Client):
+    """
+    This is a subclass of the paho.mqtt client that uses async tasks
+    instead of threads.
+
+    See `paho.mqtt.client.Client` for usage details.
+    """
+    _close_ok = False
+    _want_reconnect = False
+    _did_work = False
+
+    def __init__(self,*a,**k):
+        super().__init__(*a,**k)
+
+        del self._msgtime_mutex
+        del self._reconnect_delay_mutex
+        del self._thread
+        del self._out_packet
+
+        self._mid_generate_mutex = _null_ctx
+        self._in_callback_mutex = _null_ctx
+        self._out_message_mutex = _null_ctx
+        self._in_message_mutex = _null_ctx
+
+        self._out_q = Queue(999)
+        self._out_p = None  # packet to retransmit
+        self._connected = ValueEvent()
+
+    @asynccontextmanager
+    async def _connect_once(self):
+        self._connected = ValueEvent()
+
+        context = self._ssl_context if self._ssl else None
+        client = None
+        rc = MQTTErrorCode.MQTT_ERR_NO_CONN
+
+        self._last_msg_in = self._last_msg_out = time_func()
+
+        # Put messages in progress in a valid state.
+        self._messages_reconnect_reset()
+
+        on_pre_connect = self.on_pre_connect
+        if on_pre_connect:
+            try:
+                on_pre_connect(self, self._userdata)
+            except Exception as err:
+                self._easy_log(
+                    MQTT_LOG_ERR, 'Caught exception in on_pre_connect: %s', err)
+                if not self.suppress_exceptions:
+                    raise
+
+        try:
+            async with (
+                    ungroup_exc,
+                    await anyio.connect_tcp(self._host, self._port, ssl_context=context) as client,
+                    anyio.create_task_group() as tg,
+                    ):
+                if self._transport == "websockets":
+                    ctx = WebSock(client, self._host, self._websocket_path, self._websocket_extra_headers)
+                elif self._transport == "tcp":
+                    ctx = nullcontext(anyio.streams.stapled.StapledByteStream(
+                        client,
+                        anyio.streams.buffered.BufferedByteReceiveStream(client),
+                        ))
+                else:
+                    raise ValueError("Transport must be 'websockets' or 'tcp'")
+                async with ctx as client:
+                    self._call_socket_open(client)
+                    self._sock = client
+                    tg.start_soon(self._loop_read)
+                    tg.start_soon(self._loop_write)
+
+                    self._send_connect(self._keepalive)
+                    await self._connected.get()
+                    self._did_work = True
+                    yield self
+        except (anyio.EndOfStream, EOFError) as err:
+            if self._state != _ConnectionState.MQTT_CS_DISCONNECTING:
+                raise
+            rc = MQTTErrorCode.MQTT_ERR_SUCCESS
+        except TimeoutError:
+            rc = MQTTErrorCode.MQTT_ERR_KEEPALIVE
+        else:
+            rc = MQTTErrorCode.MQTT_ERR_SUCCESS
+        finally:
+            self._do_on_disconnect(packet_from_broker=False, v1_rc=rc)
+            if client is not None:
+                self._call_socket_close(client)
+            self._sock = None
+
+    async def wait_connected(self):
+        await self._connected.get()
+
+    async def loop_reconnect(self, task_status=anyio.TASK_STATUS_IGNORED):
+        while True:
+            try:
+                async with self._connect_once():
+                    task_status.started()
+                    task_status = anyio.TASK_STATUS_IGNORED
+                    await anyio.sleep_forever()
+
+            except (anyio.BrokenResourceError,OSError,EOFError,anyio.EndOfStream) as exc:
+                # flush packet queue
+                if self._want_reconnect:
+                    self._want_reconnect = False
+                    continue
+                if not self._did_work:
+                    raise
+
+                pkts = []
+                while True:
+                    try:
+                        pkt = self._out_q.get_nowait()
+                    except anyio.WouldBlock:
+                        break
+                    else:
+                        if pkt["command"] & 0xF0 == PUBLISH and pkt["qos"] == 0 and pkt["info"] is not None:
+                            pkt["info"].rc = MQTT_ERR_CONN_LOST
+                            pkt["info"]._set_as_published()
+                        else:
+                            pkts.append(pkt)
+
+                for pkt in pkts:
+                    self._out_q.put_nowait(pkt)
+
+            if self._state == _ConnectionState.MQTT_CS_DISCONNECTING:
+                break
+            if self._state == _ConnectionState.MQTT_CS_DISCONNECTED:
+                break
+
+            await self._reconnect_wait()
+
+
+    async def _reconnect_wait(self) -> None:
+        # See reconnect_delay_set for details
+        if self._reconnect_delay is None:
+            self._reconnect_delay = self._reconnect_min_delay
+        else:
+            self._reconnect_delay = min(
+                self._reconnect_delay * 2,
+                self._reconnect_max_delay,
+            )
+        await anyio.sleep(self._reconnect_delay)
+
+
+    def _handle_connack(self):
+        res = super()._handle_connack()
+        self._connected.set(res)
+
+    @asynccontextmanager
+    async def connect(self, *a, **k):
+        try:
+            self._close_ok = True
+            self.connect_async(*a, **k)
+        finally:
+            self._close_ok = False
+        try:
+            async with anyio.create_task_group() as tg:
+                await tg.start(self.loop_reconnect)
+                yield self
+                tg.cancel_scope.cancel()
+        except BaseExceptionGroup as exc:
+            m,r = exc.split(GeneratorExit)
+            raise r
+
+
+    def _sock_close(self):
+        if not self._close_ok:
+            raise RuntimeError("Superseded")
+
+    def _reset_sockets(self):
+        # called from __del__ thus no error raised
+        # raise RuntimeError("Superseded")
+        pass
+
+    def _packet_read(self):
+        raise RuntimeError("Superseded")
+
+    def _packet_write(self):
+        raise RuntimeError("Superseded")
+
+    def _sock_send(self, data):
+        raise RuntimeError("Superseded")
+
+    def _packet_read(self):
+        raise RuntimeError("Superseded")
+
+    def loop_read(self, max_packets=1):
+        raise RuntimeError("Superseded")
+
+    def loop_write(self):
+        pass  # no-op
+
+    def loop_forever(self):
+        raise RuntimeError("Superseded")
+
+    def reconnect(self):
+        self._want_reconnect = True
+
+    def _packet_queue(
+        self,
+        command: int,
+        packet: bytes,
+        mid: int,
+        qos: int,
+        info: MQTTMessageInfo | None = None,
+    ) -> MQTTErrorCode:
+        mpkt: _OutPacket = {
+            "command": command,
+            "mid": mid,
+            "qos": qos,
+            "packet": packet,
+            "info": info,
+        }
+        self._out_q.put_nowait(mpkt)
+        return MQTTErrorCode.MQTT_ERR_SUCCESS
+
+    async def _recv_one(self):
+        pkt = {
+            "command": 0,
+            "remaining_length": 0,
+            "packet": bytearray(b""),
+            "pos": 0,
+        }
+        pkt['command'] = (await self._sock.receive(1))[0]
+
+        length = 0
+        while True:
+            byte = (await self._sock.receive(1))[0]
+            length = (length<<7) | (byte & 127)
+            if not (byte & 128):
+                break
+
+        pkt_data = []
+        pkt['remaining_length'] = length
+
+        while length:
+            data = await self._sock.receive(length)
+            pkt_data.append(data)
+            length -= len(data)
+
+        pkt['packet'] = b''.join(pkt_data)
+
+        self._packet_seen = time_func()
+        return pkt
+
+    
+    async def _loop_read(self):
+        while True:
+            self._in_packet = await self._recv_one()
+            self._packet_handle()
+
+
+    async def _loop_write(self):
+        if self._out_p is not None:
+            packet,self._out_p = self._out_p,None
+            rc = await self._send_one(packet)
+            if rc is not None:
+                return rc
+
+        self._ping_t = 0
+        while True:
+            try:
+                with anyio.fail_after(self._keepalive):
+                    packet = await self._out_q.get()
+            except TimeoutError:
+                if self._ping_t:
+                    raise
+                self._send_pingreq()
+                self._ping_t = time_func()
+            else:
+                rc = await self._send_one(packet)
+                if rc is not None:
+                    return rc
+
+    async def _send_one(self, packet):
+        try:
+            await self._sock.send(packet['packet'])
+        except OSError as err:
+            self._out_p = packet
+            self._easy_log(
+                    MQTT_LOG_ERR, 'failed to receive on socket: %s', err)
+            return MQTTErrorCode.MQTT_ERR_CONN_LOST
+        else:
+            if (packet['command'] & 0xF0) == MessageType.PUBLISH and packet['qos'] == 0:
+                on_publish = self.on_publish
+
+                if on_publish:
+                    try:
+                        if self._callback_api_version == CallbackAPIVersion.VERSION1:
+                            on_publish = cast(mqtt.CallbackOnPublish_v1, on_publish)
+
+                            on_publish(self, self._userdata, packet["mid"])
+                        elif self._callback_api_version == CallbackAPIVersion.VERSION2:
+                            on_publish = cast(mqtt.CallbackOnPublish_v2, on_publish)
+
+                            on_publish(
+                                self,
+                                self._userdata,
+                                packet["mid"],
+                                ReasonCode(PacketTypes.PUBACK),
+                                Properties(PacketTypes.PUBACK),
+                            )
+                        else:
+                            raise RuntimeError("Unsupported callback API version")
+                    except Exception as err:
+                        raise
+                        self._easy_log(
+                            MQTT_LOG_ERR, 'Caught exception in on_publish: %s', err)
+                        if not self.suppress_exceptions:
+                            raise
+
+                # TODO: Something is odd here. I don't see why packet["info"] can't beNone.
+                # A packet could be produced by _handle_connack with qos=0 and no info
+                # (around line 3645). Ignore the mypy check for now but I feel there is a bug
+                # somewhere.
+                packet['info']._set_as_published()  # type: ignore
+
+            return None
+
+
+    async def loop_forever(
+        self,
+        retry_first_connection: bool = False,
+    ) -> MQTTErrorCode:
+        """This function calls the network loop functions for you in an
+        infinite blocking loop. It is useful for the case where you only want
+        to run the MQTT client loop in your program.
+
+        loop_forever() will handle reconnecting for you if reconnect_on_failure is
+        true (this is the default behavior). If you call `disconnect()` in a callback
+        it will return.
+
+        :param bool retry_first_connection: Should the first connection attempt be retried on failure.
+          This is independent of the reconnect_on_failure setting.
+
+        :raises OSError: if the first connection fail unless retry_first_connection=True
+        """
+
+        run = True
+
+        while run:
+            if self._state == _ConnectionState.MQTT_CS_CONNECT_ASYNC:
+                try:
+                    self.reconnect()
+                except OSError:
+                    self._handle_on_connect_fail()
+                    if not retry_first_connection:
+                        raise
+                    self._easy_log(
+                        MQTT_LOG_DEBUG, "Connection failed, retrying")
+                    await self._reconnect_wait()
+            else:
+                break
+
+        def should_exit() -> bool:
+            return self._state in (_ConnectionState.MQTT_CS_DISCONNECTING, _ConnectionState.MQTT_CS_DISCONNECTED)
+
+        while True:
+            rc = MQTTErrorCode.MQTT_ERR_SUCCESS
+            while rc == MQTTErrorCode.MQTT_ERR_SUCCESS:
+                rc = await self._loop()
+
+            if should_exit() or not self._reconnect_on_failure:
+                break
+
+            await self._reconnect_wait()
+
+            if should_exit():
+                break
+            try:
+                await self.reconnect()
+            except OSError:
+                self._handle_on_connect_fail()
+                self._easy_log(MQTT_LOG_DEBUG, "Connection failed, retrying")
+
+        return rc
+
+
+wsproto = None
+WSConnection = None
+
+class WebSock(anyio.abc.ByteStream):
+    def __init__(self, sock, host, path = "/ws", headers = {}):
+        self._sock = sock
+        self._host = host
+        self._path = path
+        self._headers = headers
+        self._rbuf = bytearray()
+        self._lock = anyio.Lock()
+        self._connected = None
+
+        global wsproto
+        if wsproto is None:
+            import wsproto
+
+    async def _xmit(self, pkt):
+        async with self._lock:
+            await self._sock.send(self._ws.send(pkt))
+
+    async def _evts(self):
+        data = await self._sock.receive()
+        self._ws.receive_data(data)
+
+        for event in self._ws.events():
+            if isinstance(event, wsproto.events.AcceptConnection):
+                self._connected = True
+            elif isinstance(event, wsproto.events.RejectConnection):
+                self._connected = False
+                logger.warning("Rejected: %s", event.data)
+            elif isinstance(event, wsproto.events.TextMessage):
+                print(f"Received message: {event.data}")
+            elif isinstance(event, wsproto.events.BytesMessage):
+                self._rbuf += event.data
+                print(f"Received bytes: {event.data}")
+            elif isinstance(event, wsproto.events.Ping):
+                print(f"Received ping: {event.payload!r}")
+            elif isinstance(event, wsproto.events.Pong):
+                print(f"Received pong: {event.payload!r}")
+            elif isinstance(event, wsproto.events.CloseConnection):
+                if self._connected is not None:
+                    self._connected = None
+                    await self._sock.send(self._ws.send(event.response()))
+                await self._sock.aclose()
+                self._sock = None
+                return
+            else:
+                raise RuntimeError("Do not know how to handle event: " + str(event))
+
+            if hasattr(event, 'response'):
+                await self._ws.send(event.response())
+
+    async def __aenter__(self):
+        self._ws = wsproto.WSConnection(wsproto.connection.CLIENT)
+        #self._ws.initiate_upgrade_connection(headers=self._headers, path=self._path)
+
+        await self._xmit(wsproto.events.Request(host=self._host,
+            target=self._path, extra_headers=list(self._headers.items()),
+            subprotocols=["mqtt"]))
+
+        while self._connected is None:
+            await self._evts()
+
+        if not self._connected:
+            raise anyio.BrokenResourceError
+
+        return self
+
+    async def __aexit__(self, *err):
+        await self.aclose()
+
+    async def send(self, bytes):
+        await self._sock.send(self._ws.send(wsproto.events.BytesMessage(data=bytes)))
+
+    async def receive(self, max_bytes=None):
+        while not self._rbuf:
+            if self._sock is None:
+                raise EOFError
+            await self._evts()
+
+        res = self._rbuf[:max_bytes]
+        self._rbuf[:max_bytes] = b''
+        return res
+
+    async def aclose(self):
+        if self._sock is None:
+            return
+
+        self._connected = None
+        await self._sock.send(self._ws.send(wsproto.events.CloseConnection(code=0)))
+        while self._sock is not None:
+            await self._evts()
+
+    async def send_eof(self):
+        pass
+

--- a/aiomqtt/queue.py
+++ b/aiomqtt/queue.py
@@ -1,0 +1,88 @@
+"""
+trio/anyio no longer have queues, but sometimes a memory object stream is
+unwieldy. Thus this re-implemens a simple queue using
+`anyio.create_memory_object_stream`.
+"""
+
+from __future__ import annotations
+
+import anyio
+from anyio import create_memory_object_stream
+
+from outcome import Error, Value
+
+from typing import TYPE_CHECKING  # isort:skip
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
+
+import logging  # isort:skip
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "Queue",
+]
+
+
+class Queue:
+    """
+    Queues have been replaced in trio/anyio by memory object streams, but
+    those are more complicated to use.
+
+    This Queue class simply re-implements queues on top of memory object streams.
+    """
+
+    def __init__(self, length=1):
+        self._s, self._r = create_memory_object_stream(length)
+
+    async def put(self, x):
+        """Send a value, blocking"""
+        await self._s.send(Value(x))
+
+    def put_nowait(self, x):
+        """Send a value, nonblocking"""
+        self._s.send_nowait(Value(x))
+
+    async def put_error(self, x):
+        """Send an error value, blocking"""
+        await self._s.send(Error(x))
+
+    async def get(self):
+        """Get the next value, blocking.
+        May raise an exception if one was sent."""
+        res = await self._r.receive()
+        return res.unwrap()
+
+    def get_nowait(self):
+        """Get the next value, nonblocking.
+        May raise an exception if one was sent."""
+        res = self._r.receive_nowait()
+        return res.unwrap()
+
+    def qsize(self):
+        """Return the number of elements in the queue"""
+        return self._s.statistics().current_buffer_used
+
+    def empty(self):
+        """Check whether the queue is empty"""
+        return self._s.statistics().current_buffer_used == 0
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        res = await self._r.__anext__()  # pylint: disable=E1101
+        return res.unwrap()
+
+    def close_sender(self):
+        """No more messages will be received"""
+        self._s.close()
+
+    close_writer = close_sender
+
+    def close_receiver(self):
+        """No more messages may be sent"""
+        self._r.close()
+
+    close_reader = close_receiver

--- a/docs/migration-guide-v3.md
+++ b/docs/migration-guide-v3.md
@@ -1,0 +1,41 @@
+# Migration guide: v3.0.0
+
+Version 3.0.0 transitions to `anyio` instead of using `asyncio` directly.
+
+This means
+
+- use the `anyio.run` wrapper, your choice of back-end
+- publish and subscribe/unsubscribe methods no longer have a `timeout` argument.
+
+## Use `anyio.run`
+
+The preferred way to start an async program using anyio is to use
+`anyio.run(main, backend='asyncio')`.
+
+`anyio.run(main, backend='trio')` is generally a bit slower than asyncio;
+this is offset by the fact that anyio needs to do much less work to
+provide an environment where error propagation and task cancellation
+Just Work.
+
+Also, trio affords better error messages and introspection.
+
+For the underlying philosophy behind Trio, see
+https://vorpus.org/blog/notes-on-structured-concurrency-or-go-statement-considered-harmful/ .
+
+## No more timeout arguments
+
+The `publish`, `subscribe` and `unsubscribe` methods no longer have a `timeout` argument.
+
+If you do need to use a timeout on any of these commands, you can use asyncio's 
+`wait_for` wrapper, or (even easier) anyio's context manager:
+
+```python
+import anyio
+import aiomqtt
+
+async def main():
+    async with aiomqtt.Client("test.mosquitto.org") as client:
+        with anyio.fail_after(3.5):
+            await client.publish("temperature/outside", payload=28.4)
+
+anyio.run(main)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.8"
 paho-mqtt = "^2.0.0"
+anyio = "^4.3"
 typing-extensions = {version = "^4.4.0", markers = "python_version < '3.10'"}
 
 [tool.poetry.group.dev]
@@ -31,7 +32,6 @@ mypy = "^1.9.0"
 ruff = "^0.1.9"
 pytest = "^7.3.1"
 pytest-cov = "^4.0.0"
-anyio = "^3.6.2"
 furo = "^2023.3.27"
 sphinx-autobuild = "^2021.3.14"
 myst-parser = "^1.0.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,10 +6,7 @@ from typing import Any
 import pytest
 
 
+# No longer needed, this also works with Trio
 @pytest.fixture
 def anyio_backend() -> tuple[str, dict[str, Any]]:
-    if sys.platform == "win32":
-        from asyncio.windows_events import WindowsSelectorEventLoopPolicy
-
-        return ("asyncio", {"policy": WindowsSelectorEventLoopPolicy()})
-    return ("asyncio", {})
+    return ("trio", {})

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,6 +4,7 @@ import logging
 import pathlib
 import ssl
 import sys
+import uuid
 
 import anyio
 import anyio.abc
@@ -29,8 +30,7 @@ from aiomqtt.types import PayloadType
 pytestmark = pytest.mark.anyio
 
 HOSTNAME = "test.mosquitto.org"
-OS_PY_VERSION = sys.platform + "_" + ".".join(map(str, sys.version_info[:2]))
-TOPIC_PREFIX = OS_PY_VERSION + "/tests/aiomqtt/"
+TOPIC_PREFIX = str(uuid.uuid1()) + "/aiomqtt/"
 
 
 @pytest.mark.network


### PR DESCRIPTION
As per https://github.com/sbtinstruments/aiomqtt/discussions/226 here's a draft of an anyio-ified aiomqtt. It abuses paho-mqtt 2.0 by way of subclassing its `Client` class.

No more threads. No more issues with locking. Trio compatibility.

Tests pass (one failure on asyncio) but there's still a lot to do; checking robustness and handling reconnections and getting typing back up to standard and finishing the paho callback API v2 transition and support for paho-mqtt 2.1 and general clean-up and support for more MQTTv5 features and whatnot.

I need this code in order to replace my `moat-mqtt` package  (which is a hbmqtt port to anyio that shows its age). No guarantees but I plan to keep poking at this.