### PR TITLE
Improve message routing

### DIFF
--- a/aiomqtt/__init__.py
+++ b/aiomqtt/__init__.py
@@ -8,6 +8,7 @@ from .client import (
 )
 from .exceptions import MqttCodeError, MqttError, MqttReentrantError
 from .message import Message
+from .router import Router
 from .topic import Topic, TopicLike, Wildcard, WildcardLike
 
 # These are placeholders that are managed by poetry-dynamic-versioning
@@ -19,6 +20,7 @@ __all__ = [
     "__version_tuple__",
     "Client",
     "Message",
+    "Router",
     "ProtocolVersion",
     "ProxySettings",
     "TLSParameters",

--- a/aiomqtt/router.py
+++ b/aiomqtt/router.py
@@ -1,0 +1,11 @@
+class Router:
+    def __init__(self) -> None:
+        self._handlers = {}
+
+    def match(self, *args: str):
+        """Add a new handler with one or multiple wildcards to the router."""
+        def decorator(func):
+            for wildcard in args:
+                self._handlers[wildcard] = func
+            return func
+        return decorator


### PR DESCRIPTION
This proposes a simpler way to filter messages and structure message handling.

Unsorted points that I considered:

- This lets us split message handling into multiple files via multiple routers
- This lets us use the client inside a handler function, to e.g. publish a message back in a request/response fashion
- We can dynamically subscribe and unsubscribe
- The values of wildcards (`+`/`#`) of the topic filter are automatically available as `*args` in the handler function
- We still only have a single message queue (easier for newcomers, concurrency could be implemented as shown below, optionally with priority queue)
- We can still pass a non-default queue to the client to prioritize the handling of certain messages
- We still have flexibility to not use the routers, but handle the messages directly. Routers are a natural development, once the application gets too complex we can iteratively add them
- We are still flexible enough to [process messages concurrently](https://sbtinstruments.github.io/aiomqtt/subscribing-to-a-topic.html#processing-concurrently) in an individual way
- It's a non-breaking change

The interface looks like this:

```python
router = aiomqtt.Router()


@router.match("humidity/+/inside/#")
async def handle(message, client, *args):  # automatically extract wildcards into *args
    print(message.payload)


async with aiomqtt.Client("test.mosquitto.org", routers=[router]) as client:
    await client.subscribe("humidity/#")
    async for message in client.messages:
        await client.route(message)
```

Where we can process messages concurrently e.g. like this:


```python
router = aiomqtt.Router()


@router.match("humidity/+/inside/#")
async def handle(message, client, *args):  # automatically extract wildcards into *args
    print(message.payload)


async def work(client):
    async for message in client._messages():
        await client.route(message)


async with aiomqtt.Client("test.mosquitto.org", routers=[router]) as client:
    await client.subscribe("humidity/#")
    async with asyncio.TaskGroup() as tg:
        tg.create_task(work(client))
        tg.create_task(work(client))
```

(`.messages` is currently broken, for now we use `._messages()` to be able to use it multiple times.)

Glad to hear feedback on this 🙂