### PR TITLE
Update FastAPI doc to use dependency injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Bump paho-mqtt to 2.1 (@empicano in #305)
 - Migrate to paho-mqtt callback v2 (@empicano in #313)
+- Update FastAPI example in the documentation (@odie5533 in #321)
 
 ### Fixed
 

--- a/docs/alongside-fastapi-and-co.md
+++ b/docs/alongside-fastapi-and-co.md
@@ -6,9 +6,10 @@ With [FastAPI](https://github.com/tiangolo/fastapi) (`0.93+`) and [Starlette](ht
 
 ```python
 import asyncio
+from typing import Annotated
 import aiomqtt
-import contextlib
-import fastapi
+from contextlib import asynccontextmanager
+from fastapi import Depends, FastAPI
 
 
 async def listen(client):
@@ -19,8 +20,12 @@ async def listen(client):
 client = None
 
 
-@contextlib.asynccontextmanager
-async def lifespan(app):
+async def get_mqtt():
+    yield client
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
     global client
     async with aiomqtt.Client("test.mosquitto.org") as c:
         # Make client globally available
@@ -39,11 +44,11 @@ async def lifespan(app):
             pass
 
 
-app = fastapi.FastAPI(lifespan=lifespan)
+app = FastAPI(lifespan=lifespan)
 
 
 @app.get("/")
-async def publish():
+async def publish(client: Annotated[aiomqtt.Client, Depends(get_mqtt)]):
     await client.publish("humidity/outside", 0.38)
 ```
 


### PR DESCRIPTION
Update the doc example for integration with FastAPI to use FastAPI's dependency injection for the MQTT client

Closes https://github.com/sbtinstruments/aiomqtt/issues/320